### PR TITLE
Remove short sections from the center line

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -129,6 +129,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +275,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +345,16 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -588,6 +620,7 @@ dependencies = [
  "geo-buffer",
  "geojson",
  "log",
+ "petgraph",
  "serde",
 ]
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -132,6 +132,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +406,16 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pkg-config"
@@ -592,6 +624,7 @@ dependencies = [
  "geo-buffer",
  "geojson",
  "log",
+ "petgraph",
  "serde",
 ]
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -48,6 +48,7 @@
     filter_skeletons_outside: true,
     filter_skeletons_near_boundary: 0.1,
     join_skeletons: true,
+    remove_short_skeletons: 0.1,
 
     make_perps_step_size: 5.0,
   };

--- a/web/src/Settings.svelte
+++ b/web/src/Settings.svelte
@@ -34,6 +34,12 @@
   </div>
 
   <OptionalNumber
+    label="Remove short skeleton lines less than this ratio (to the longest)"
+    bind:value={cfg.remove_short_skeletons}
+    defaultNumber={0.1}
+  />
+
+  <OptionalNumber
     label="Generate perpendicular lines at this step size (m)"
     bind:value={cfg.make_perps_step_size}
     defaultNumber={5.0}

--- a/widths/Cargo.toml
+++ b/widths/Cargo.toml
@@ -9,4 +9,5 @@ geo = "0.28.0"
 geo-buffer = { git = "https://github.com/MarcioOrdonez/geo-buffer", branch = "chore/bump-geo-version-to-v.0.25.0" }
 geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"] }
 log = "0.4.21"
+petgraph = "0.6.5"
 serde = { version = "1.0.203", features = ["derive"] }


### PR DESCRIPTION
Pretty much fixes #2, though it introduces (or exposes) some new problems.

The approach is:
1) Take all the raw straight skeleton lines and form a graph
2) Find the longest path in that graph (by brute-forcing every possibility. the graphs are tiny, so this is totally fine)
3) Join those lines together, and repeat until everything is merged
4) Look at (length of skeleton line) / (length of longest skeleton line). If it's under some threshold, remove it

As an illustration, here's the longest joined-up line in an example in blue:
![Screenshot from 2024-06-13 14-55-56](https://github.com/dabreegster/polygon-width/assets/1664407/3b5e0c20-4416-4cac-ac54-689a9a6fc9eb)
The leftover red bits are short relative to the blue, so the default 10% threshold removes them, and the final result is much cleaner:
![image](https://github.com/dabreegster/polygon-width/assets/1664407/77348031-b393-4966-93cf-e39ffed3a9cd)

Here's a more complex example, with 1m step size and the thickened polygons shown. The cyan shapes are starting to very nicely approximate the input shape. The biggest problem in this case is now how the thickened polygons are found, but that's really just for visualization and scoring -- the core center line and width calculations look usable to me!
![image](https://github.com/dabreegster/polygon-width/assets/1664407/71facf6a-24a6-4c32-be01-3c1f0e42edb5)


Still some improvement possible. When a skeleton has a fork like this:
![image](https://github.com/dabreegster/polygon-width/assets/1664407/21cc124a-7e94-4532-9404-86caf8e78042)
The joined thing picks the longer side and keeps it. That's not the worse, but ideally the center line would get closer to the input polygon's edge.
![image](https://github.com/dabreegster/polygon-width/assets/1664407/d06bc368-364d-4a69-97b2-9f980b8fd180)

The loop example is also turning into one big long linestring, including a double-back in the path. This is weird/wrong, bu this example was already broken before (no perpendiculars). Probably need to handle loops a little differently.
![image](https://github.com/dabreegster/polygon-width/assets/1664407/54fb8992-47c5-40c7-aaa0-b21845dd4ee2)